### PR TITLE
Avoid crashing of the proxy server.

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -965,6 +965,7 @@ function Miner(id, params, ip, pushMessage, portData, minerSocket) {
 
     this.cachedJob = null;
 
+    if (!params.pass) params.pass = "x";
     let pass_split = params.pass.split(":");
     this.identifier = global.config.addressWorkerID ? this.user : pass_split[0];
 


### PR DESCRIPTION
If a miner is using an empty password, the proxy server crash.. Simply set a "x" password as default when password isnt set, avoid the crash.